### PR TITLE
New Feature of Private Cache for Concurrency

### DIFF
--- a/Source/carthage/Update.swift
+++ b/Source/carthage/Update.swift
@@ -15,6 +15,7 @@ public struct UpdateCommand: CommandProtocol {
 		public let buildOptions: CarthageKit.BuildOptions
 		public let checkoutOptions: CheckoutCommand.Options
 		public let dependenciesToUpdate: [String]?
+		public let isPrivateCache: Bool
 
 		/// The build options corresponding to these options.
 		public var buildCommandOptions: BuildCommand.Options {
@@ -25,7 +26,8 @@ public struct UpdateCommand: CommandProtocol {
 				isVerbose: isVerbose,
 				directoryPath: checkoutOptions.directoryPath,
 				logPath: logPath,
-				dependenciesToBuild: dependenciesToUpdate
+				dependenciesToBuild: dependenciesToUpdate,
+				isPrivateCache: isPrivateCache
 			)
 		}
 
@@ -46,7 +48,8 @@ public struct UpdateCommand: CommandProtocol {
 		             isVerbose: Bool,
 		             logPath: String?,
 		             buildOptions: BuildOptions,
-		             checkoutOptions: CheckoutCommand.Options)
+		             checkoutOptions: CheckoutCommand.Options,
+		             isPrivateCache: Bool)
 		{
 			self.checkoutAfterUpdate = checkoutAfterUpdate
 			self.buildAfterUpdate = buildAfterUpdate
@@ -55,6 +58,7 @@ public struct UpdateCommand: CommandProtocol {
 			self.buildOptions = buildOptions
 			self.checkoutOptions = checkoutOptions
 			self.dependenciesToUpdate = checkoutOptions.dependenciesToCheckout
+			self.isPrivateCache = isPrivateCache
 		}
 
 		public static func evaluate(_ mode: CommandMode) -> Result<Options, CommandantError<CarthageError>> {
@@ -70,6 +74,7 @@ public struct UpdateCommand: CommandProtocol {
 				<*> mode <| Option(key: "log-path", defaultValue: nil, usage: "path to the xcode build output. A temporary file is used by default")
 				<*> BuildOptions.evaluate(mode, addendum: "\n(ignored if --no-build option is present)")
 				<*> CheckoutCommand.Options.evaluate(mode, useBinariesAddendum: binariesAddendum, dependenciesUsage: dependenciesUsage)
+				<*> mode <| Option(key: "private-cache", defaultValue: false, usage: "creates different cache folder")
 		}
 
 		/// Attempts to load the project referenced by the options, and configure it


### PR DESCRIPTION
Adding a new feature of private cache for the builds to achieve concurrency.

Update:

Issue:
1. While running Carthage update concurrently then one build fails.
2. Since build share once common cache i.e. ~/Library/Caches/org.carthage.CarthageKit/.

Fix:
1. Adding a feature of private cache for the builds to achieve concurrency while running Carthage update.
2. With the fix user has to include additional build parameter i.e. --private-cache and the build will have it's own private cache.
e.g.:  carthage update --platform ios --private-cache